### PR TITLE
fix: `Importable._bone_translation_table` needs to be an instance attribute

### DIFF
--- a/src/viur/toolkit/importer/importable.py
+++ b/src/viur/toolkit/importer/importable.py
@@ -98,7 +98,11 @@ class Importable:
         "inform": False,  # either an e-mail address to inform, or True for current user, False otherwise.
         "clear": True,  # Do do_clear and delete not imported entries
     }
-    _bone_translation_table: dict[str, dict] = {}  # the final translation table once created by create_config()
+
+    def __init__(self):
+        super().__init__()
+        self._bone_translation_table: dict[str, dict] = {}
+        """the final translation table once created by create_config()"""
 
     def modify_skel_key(
         self,

--- a/src/viur/toolkit/importer/importable.py
+++ b/src/viur/toolkit/importer/importable.py
@@ -99,8 +99,8 @@ class Importable:
         "clear": True,  # Do do_clear and delete not imported entries
     }
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+        super().__init__(*args, **kwargs)
         self._bone_translation_table: dict[str, dict] = {}
         """the final translation table once created by create_config()"""
 

--- a/src/viur/toolkit/importer/importable.py
+++ b/src/viur/toolkit/importer/importable.py
@@ -99,7 +99,7 @@ class Importable:
         "clear": True,  # Do do_clear and delete not imported entries
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._bone_translation_table: dict[str, dict] = {}
         """the final translation table once created by create_config()"""


### PR DESCRIPTION
Otherwise, multiple modules would share the same translation tables.