### PR TITLE
feat: Support `viur-core>=3.7`; Use `_private_bucket` for reports' storage place

### DIFF
--- a/src/viur/toolkit/report.py
+++ b/src/viur/toolkit/report.py
@@ -9,13 +9,13 @@ from types import TracebackType
 from google.cloud.storage import Bucket
 
 from viur.core import email
-from viur.core.modules.file import GOOGLE_STORAGE_BUCKET
+from viur.core.modules.file import _private_bucket
 
 __all__ = ["Report"]
 
 logger = logging.getLogger(__name__)
 
-GOOGLE_STORAGE_BUCKET: Bucket = GOOGLE_STORAGE_BUCKET
+GOOGLE_STORAGE_BUCKET: Bucket = _private_bucket
 """Main GOOGLE_STORAGE_BUCKET (here reassigned to add the type hint)"""
 
 

--- a/src/viur/toolkit/report.py
+++ b/src/viur/toolkit/report.py
@@ -20,8 +20,8 @@ if tuple(map(int, core_version.split(".", 2)[:2])) >= (3, 7):
     GOOGLE_STORAGE_BUCKET: Bucket = File.get_bucket("")
     """Main (private) GOOGLE_STORAGE_BUCKET"""
 else:
-    from viur.core.modules.file import GOOGLE_STORAGE_BUCKET
-    GOOGLE_STORAGE_BUCKET: Bucket = GOOGLE_STORAGE_BUCKET  # type: ignore[no-redef]
+    from viur.core.modules.file import GOOGLE_STORAGE_BUCKET  # type: ignore[no-redef]
+    GOOGLE_STORAGE_BUCKET: Bucket = GOOGLE_STORAGE_BUCKET
     """Main GOOGLE_STORAGE_BUCKET (here reassigned to add the type hint)"""
 
 class Report:

--- a/src/viur/toolkit/report.py
+++ b/src/viur/toolkit/report.py
@@ -21,7 +21,7 @@ if tuple(map(int, core_version.split(".", 2)[:2])) >= (3, 7):
     """Main (private) GOOGLE_STORAGE_BUCKET"""
 else:
     from viur.core.modules.file import GOOGLE_STORAGE_BUCKET
-    GOOGLE_STORAGE_BUCKET: Bucket = GOOGLE_STORAGE_BUCKET
+    GOOGLE_STORAGE_BUCKET: Bucket = GOOGLE_STORAGE_BUCKET  # type: ignore[no-redef]
     """Main GOOGLE_STORAGE_BUCKET (here reassigned to add the type hint)"""
 
 class Report:

--- a/src/viur/toolkit/report.py
+++ b/src/viur/toolkit/report.py
@@ -9,15 +9,20 @@ from types import TracebackType
 from google.cloud.storage import Bucket
 
 from viur.core import email
-from viur.core.modules.file import _private_bucket
+from viur.core.version import __version__ as core_version
+from viur.core.modules.file import File
 
 __all__ = ["Report"]
 
 logger = logging.getLogger(__name__)
 
-GOOGLE_STORAGE_BUCKET: Bucket = _private_bucket
-"""Main GOOGLE_STORAGE_BUCKET (here reassigned to add the type hint)"""
-
+if tuple(map(int, core_version.split(".", 2)[:2])) >= (3, 7):
+    GOOGLE_STORAGE_BUCKET: Bucket = File.get_bucket("")
+    """Main (private) GOOGLE_STORAGE_BUCKET"""
+else:
+    from viur.core.modules.file import GOOGLE_STORAGE_BUCKET
+    GOOGLE_STORAGE_BUCKET: Bucket = GOOGLE_STORAGE_BUCKET
+    """Main GOOGLE_STORAGE_BUCKET (here reassigned to add the type hint)"""
 
 class Report:
     """Reports are a kind of logging


### PR DESCRIPTION
For now it's intended to save reports into the private bucket.

This PR is related to PRs from viur-core : https://github.com/viur-framework/viur-core/pull/1266 and https://github.com/viur-framework/viur-core/pull/1268