### PR TITLE
fix: Don't remove `-viur` from project_id

### DIFF
--- a/src/viur/toolkit/importer/importable.py
+++ b/src/viur/toolkit/importer/importable.py
@@ -391,9 +391,7 @@ class Importable:
                     stringTemplate=JINJA_EMAIL_TEMPLATE,
                     skel={
                         "sourceportal": import_conf["source"]["url"],
-                        "targetportal": conf.instance.project_id.replace(
-                            "-viur", ""
-                        ),
+                        "targetportal": conf.instance.project_id,
                         "sourcemodule": import_conf.get("module", self.moduleName),
                         "targetmodule": self.moduleName,
                         "total": total,
@@ -797,9 +795,7 @@ class Importable:
                 stringTemplate=JINJA_EMAIL_TEMPLATE,
                 skel={
                     "sourceportal": import_conf["source"]["url"],
-                    "targetportal": conf.instance.project_id.replace(
-                        "-viur", ""
-                    ),
+                    "targetportal": conf.instance.project_id,
                     "sourcemodule": import_conf.get("module", self.moduleName),
                     "targetmodule": self.moduleName,
                     "total": total,


### PR DESCRIPTION
I don't know why this was done, but its obsolete.
I think it was to give the customer a better feeling? ;-)