### PR TITLE
fix: `_convert_entry` should also use _bone_translation_table.get()

### DIFF
--- a/src/viur/toolkit/importer/importable.py
+++ b/src/viur/toolkit/importer/importable.py
@@ -570,7 +570,7 @@ class Importable:
         ret = imp.values_to_skel(
             skel,
             values,
-            self._bone_translation_table[import_conf_name],
+            translate=self._bone_translation_table.get(import_conf_name) or {},
             source_key="key" if "key" in values else "id",  # ViUR 1.x
             enforce=enforce,
             debug=debug,


### PR DESCRIPTION
This is safer.