### PR TITLE
fix: `Importer.logout` only when there is a login-method

### DIFF
--- a/src/viur/toolkit/importer/importer.py
+++ b/src/viur/toolkit/importer/importer.py
@@ -79,7 +79,7 @@ class Importer(requests.Session):
             raise IOError(f"Unable to logon to '{self.host}'")
 
     def logout(self) -> t.Any:
-        if self.method != "secretkey":
+        if self.method and self.method != "secretkey":
             return self.get("/user/logout", params={"skey": self.skey()}, timeout=30).json()
 
     def skey(self) -> str:


### PR DESCRIPTION
I've found this when creating an importer that reads from a public ViUR source. There's no logout needed (and also fails with 401).