### PR TITLE
fix: variables were swapped 

### DIFF
--- a/src/viur/toolkit/importer/importer.py
+++ b/src/viur/toolkit/importer/importer.py
@@ -548,8 +548,8 @@ class Importer(requests.Session):
 
                 logger.debug(f"{value=} [OUT]")
 
-            new_value_as_str = html.unescape(str(bone_value)).strip()
-            old_value_as_str = html.unescape(str(value)).strip()
+            old_value_as_str = html.unescape(str(bone_value)).strip()
+            new_value_as_str = html.unescape(str(value)).strip()
 
             if debug:
                 logger.debug(


### PR DESCRIPTION
`bone_value` is the old value `value` the new one.

Cause no problems in the import itself, just confusion during debugging.