### PR TITLE
fix: `db.set_status()` can't be called within a transaction

### DIFF
--- a/src/viur/toolkit/db.py
+++ b/src/viur/toolkit/db.py
@@ -159,15 +159,18 @@ def set_status(
         return obj
 
     # Retry loop
-    while True:
-        try:
-            return db.RunInTransaction(transaction)
+    if not db.IsInTransaction:
+        while True:
+            try:
+                return db.RunInTransaction(transaction)
 
-        except db.ViurDatastoreError as e:
-            retry -= 1
-            if retry <= 0:
-                raise
+            except db.ViurDatastoreError as e:
+                retry -= 1
+                if retry <= 0:
+                    raise
 
-            logging.debug(f"{e}, retrying {retry} more times")
+                logging.debug(f"{e}, retrying {retry} more times")
 
-        time.sleep(1)
+            time.sleep(1)
+    else:
+        return transaction()

--- a/src/viur/toolkit/db.py
+++ b/src/viur/toolkit/db.py
@@ -169,7 +169,8 @@ def set_status(
                 if retry <= 0:
                     raise
 
-            logging.debug(f"{e}, retrying {retry} more times")
+                logging.debug(f"{e}, retrying {retry} more times")
+
             time.sleep(1)
     else:
         return transaction()

--- a/src/viur/toolkit/db.py
+++ b/src/viur/toolkit/db.py
@@ -158,19 +158,20 @@ def set_status(
 
         return obj
 
-    # Retry loop
-    if not db.IsInTransaction:
-        while True:
-            try:
-                return db.RunInTransaction(transaction)
-
-            except db.ViurDatastoreError as e:
-                retry -= 1
-                if retry <= 0:
-                    raise
-
-                logging.debug(f"{e}, retrying {retry} more times")
-
-            time.sleep(1)
-    else:
+    # In case of already in transaction, just call the function.
+    if db.IsInTransaction:
         return transaction()
+
+    # Otherwise, run the retry loop
+    while True:
+        try:
+            return db.RunInTransaction(transaction)
+
+        except db.ViurDatastoreError as e:
+            retry -= 1
+            if retry <= 0:
+                raise
+
+            logging.debug(f"{e}, retrying {retry} more times")
+
+        time.sleep(1)

--- a/src/viur/toolkit/db.py
+++ b/src/viur/toolkit/db.py
@@ -169,8 +169,7 @@ def set_status(
                 if retry <= 0:
                     raise
 
-                logging.debug(f"{e}, retrying {retry} more times")
-
+            logging.debug(f"{e}, retrying {retry} more times")
             time.sleep(1)
     else:
         return transaction()


### PR DESCRIPTION
This PR fixes `RecursionError: Cannot call runInTransaction while inside a transaction!` that is raised when `set_status()` is called from within an existing transaction.