### PR TITLE
feat: Implement `format_number`

### DIFF
--- a/src/viur/toolkit/numeric.py
+++ b/src/viur/toolkit/numeric.py
@@ -12,28 +12,28 @@ def round_decimal(value: float, frac_digits: int = 2) -> float:
     return round(value * (10 ** frac_digits), 0) / (10 ** frac_digits)
 
 
-def format_number(value: float, frac_digits: int = 2, decimal_separator: str = "") -> str:
+def format_number(value: float, frac_digits: int = 2, thousands_separator: str = "") -> str:
     """
     Format a floating-point number with a specified number of fractional digits
-    and an optional custom decimal separator.
+    and an optional custom thousands separator.
 
     The function formats the given number using thousands separators and the specified
-    number of digits after the decimal point. If a custom decimal separator is provided,
-    it replaces the thousands separator in the integer part.
+    number of digits after the decimal point. If a custom thousands separator is provided,
+    it's used in the integer part.
 
     :param value: The number to format.
     :param frac_digits: Number of digits to display after the decimal point. Defaults to 2.
-    :param decimal_separator: Custom character to use as the thousands separator.
-                              If empty, no thousands separator is used.
+    :param thousands_separator: Custom character to use as the thousands separator.
+        If empty, no thousands separator is used.
     :return: The formatted number as a string.
     """
     format_str = "{{:,.{}f}}".format(frac_digits)
     number_str = format_str.format(value)
     if frac_digits > 0:
         before, after = number_str.split(".")
-        before = before.replace(",", decimal_separator)
+        before = before.replace(",", thousands_separator)
         return f"{before},{after}"
-    return number_str.replace(",", decimal_separator)
+    return number_str.replace(",", thousands_separator)
 
 
 format_currency = deprecated(  # type: ignore

--- a/src/viur/toolkit/numeric.py
+++ b/src/viur/toolkit/numeric.py
@@ -1,4 +1,10 @@
-__all__ = ["round_decimal", "format_currency"]
+from deprecated import deprecated
+
+__all__ = [
+    "round_decimal",
+    "format_number",
+    "format_currency",
+]
 
 
 def round_decimal(value: float, frac_digits: int = 2) -> float:
@@ -6,7 +12,28 @@ def round_decimal(value: float, frac_digits: int = 2) -> float:
     return round(value * (10 ** frac_digits), 0) / (10 ** frac_digits)
 
 
-def format_currency(value: float, frac_digits: int = 2) -> str:
-    before, after = "{:,.2f}".format(round_decimal(value, frac_digits)).split(".")
-    before = before.replace(",", ".")
-    return f"{before},{after}"
+def format_number(value: float, frac_digits: int = 2, decimal_separator: str = "") -> str:
+    """
+    Format a floating-point number with a specified number of fractional digits
+    and an optional custom decimal separator.
+
+    The function formats the given number using thousands separators and the specified
+    number of digits after the decimal point. If a custom decimal separator is provided,
+    it replaces the thousands separator in the integer part.
+
+    :param value: The number to format.
+    :param frac_digits: Number of digits to display after the decimal point. Defaults to 2.
+    :param decimal_separator: Custom character to use as the thousands separator.
+                              If empty, no thousands separator is used.
+    :return: The formatted number as a string.
+    """
+    format_str = "{{:,.{}f}}".format(frac_digits)
+    number_str = format_str.format(value)
+    if frac_digits > 0:
+        before, after = number_str.split(".")
+        before = before.replace(",", decimal_separator)
+        return f"{before},{after}"
+    return number_str.replace(",", decimal_separator)
+
+
+format_currency = deprecated(format_number, reason="format_currency has been renamed to format_number", version="0.5.0")

--- a/src/viur/toolkit/numeric.py
+++ b/src/viur/toolkit/numeric.py
@@ -36,4 +36,8 @@ def format_number(value: float, frac_digits: int = 2, decimal_separator: str = "
     return number_str.replace(",", decimal_separator)
 
 
-format_currency = deprecated(format_number, reason="format_currency has been renamed to format_number", version="0.5.0")
+format_currency = deprecated(  # type: ignore
+    format_number,
+    reason="format_currency has been renamed to format_number",
+    version="0.5.0",
+)


### PR DESCRIPTION
That's a better version of `format_currency`.
Since this has no currency-specific implementation, it's a better, more generic name. Furthermore, a bug that always used two digits has been fixed.