### PR TITLE
feat: Replace logging msg with f-string

### DIFF
--- a/src/viur/toolkit/importer/importer.py
+++ b/src/viur/toolkit/importer/importer.py
@@ -228,7 +228,7 @@ class Importer(requests.Session):
             try:
                 size = int(size)
             except ValueError:
-                logger.error("cannot convert {size!r} to int", size)
+                logger.error(f"cannot convert {size!r} to int")
                 return None
 
         if size > 200_000_000:


### PR DESCRIPTION
Crashes with:
```
  File "/layers/google.python.pip/pip/lib/python3.12/site-packages/viur/toolkit/importer/importer.py", line 231, in import_file
    logger.error("cannot convert {size!r} to int", size)
  File "/layers/google.python.runtime/python/lib/python3.12/logging/__init__.py", line 1568, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/layers/google.python.runtime/python/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "/layers/google.python.runtime/python/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/layers/google.python.runtime/python/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "/layers/google.python.runtime/python/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "/layers/google.python.pip/pip/lib/python3.12/site-packages/viur/core/logging.py", line 21, in emit
    message = super(ViURDefaultLogger, self).format(record)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.runtime/python/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.runtime/python/lib/python3.12/logging/__init__.py", line 703, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.runtime/python/lib/python3.12/logging/__init__.py", line 392, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting"
```