### PR TITLE
feat: Support the newer login process of `viur-core>=3.8`

### DIFF
--- a/src/viur/toolkit/importer/importer.py
+++ b/src/viur/toolkit/importer/importer.py
@@ -151,6 +151,8 @@ class Importer(requests.Session):
                     if res:
                         if res == "OKAY":
                             break
+                        elif res["action"] == "login_success":
+                            break
                         elif self.method == "userpassword+otp" and res["action"] == "otp":
                             answ = self.post("/user/f2_timebasedotp/otp",
                                              data={"otptoken": self.otp,


### PR DESCRIPTION
login-success response has been changed in https://github.com/viur-framework/viur-core/pull/1554