### PR TITLE
fix: invalid using_skel check and catch TypeError

### DIFF
--- a/src/viur/toolkit/importer/importer.py
+++ b/src/viur/toolkit/importer/importer.py
@@ -458,7 +458,7 @@ class Importer(requests.Session):
                     raise ValueError()
 
                 # In case of an using_skel, check for differences also.
-                if using_skel:
+                if using_skel is not None:
                     using_skel.unserialize(oentry["rel"] if oentry else {})
                     changes += self.translate(
                         using_skel, nentry["rel"] or {},
@@ -764,7 +764,7 @@ class Importer(requests.Session):
 
         try:
             key = db.Key.from_legacy_urlsafe(values[source_key])
-        except AttributeError:
+        except (AttributeError, TypeError):
             key = db.keyHelper(values[source_key], skel.kindName)
 
         key = db.Key(skel.kindName, key.id_or_name)


### PR DESCRIPTION
Solves two bugs that appeared in a customer project that uses viur-core 3.8.11 and Python 3.13.