### PR TITLE
feat(`CachedProperty`): add `clear()` to drop the cached value early

### DIFF
--- a/src/viur/toolkit/property.py
+++ b/src/viur/toolkit/property.py
@@ -46,3 +46,12 @@ class CachedProperty(t.Generic[Value, Args]):
         self._value = self.func(*self.args)
         self._lifetime_ends = utils.utcNow() + self.lifetime
         return self._value
+
+    def clear(self) -> None:
+        """Drop the cached value; the next :meth:`get` call recomputes it.
+
+        Use this when an external event invalidates the cache before the
+        configured ``lifetime`` has expired.
+        """
+        self._value = None
+        self._lifetime_ends = None


### PR DESCRIPTION
External events (e.g. a write that invalidates the underlying data) can now reset the cache without having to wait for `lifetime` to expire or poking the private `_value` / `_lifetime_ends` slots directly. Mirrors the `clear()` semantics of `MemcacheWrapper`.