### PR TITLE
fix: `set_status` never ran in a transaction (`db.IsInTransaction` not called)

### DIFF
--- a/src/viur/toolkit/db.py
+++ b/src/viur/toolkit/db.py
@@ -80,6 +80,12 @@ def set_status(
 
     If the function does not raise an Exception, all went well.
     It returns either the assigned skel, or the db.Entity on success.
+
+    The read-check-write cycle always runs inside a datastore transaction:
+    if a transaction is already open, it joins it; otherwise a new one is
+    opened (with up to *retry* attempts on :exc:`db.ViurDatastoreError`).
+    This makes the precondition check and the write atomic -- concurrent
+    modifications of the same entity cannot be lost or interleaved.
     """
     if key is None and skel is None:
         raise ValueError("No Key is provided")
@@ -160,7 +166,7 @@ def set_status(
         return obj
 
     # In case of already in transaction, just call the function.
-    if db.IsInTransaction:
+    if db.IsInTransaction():
         return transaction()
 
     # Otherwise, run the retry loop


### PR DESCRIPTION
#### Problem
`set_status` in `toolkit/db.py` contains:

```python
# In case of already in transaction, just call the function.
if db.IsInTransaction:
    return transaction()
```

`db.IsInTransaction` is a **function** (`viur.core.db.utils.IsInTransaction`), so the condition tests the function object itself — which is always truthy. Consequences:

- `set_status` **always** takes the "already in transaction" shortcut and executes `transaction()` directly, without ever opening a transaction
- the `db.RunInTransaction` retry loop below is unreachable dead code (the `retry` parameter has no effect)
- every read-check-write cycle built on `set_status` (precondition checks, `+`/`-` counter mutations, status changes) is **not atomic** — concurrent modifications of the same entity can interleave and lose updates

This is particularly relevant for consumers like viur-shop, where all order status transitions (`set_ordered` / `set_paid` / `set_rts`, payment appends) rely on `set_status` and can race with concurrent payment-provider callbacks (return handler vs. webhook).

Introduced with #25, which added the in-transaction shortcut but missed the call parentheses.

#### Solution
Call the function: `if db.IsInTransaction():`. Also documented the transactional behaviour in the `set_status` docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)